### PR TITLE
fix typescript annotations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,11 +7,6 @@ export interface SearchTypes {
   VIDEO: "EgIQAQ%3D%3D";
 }
 
-const Constants = {
-  SearchTypes,
-  YoutubeURL: URL.prototype,
-}
-
 export interface Thumbnail {
   url: string;
   width: number;
@@ -79,16 +74,22 @@ export interface SearchOptions {
   language?: string;
 }
 
-class Scraper {
+declare class Scraper {
   private _lang: string;
 
   public constructor(language?: string);
 
-  private _extractData(json: Record<string, unknown>): Record<string, unknown>[];
-  private _fetch(search_query: string, searchType?: keyof SearchTypes, requestedLang?: string): Promise<string>;
+  private _extractData(
+    json: Record<string, unknown>
+  ): Record<string, unknown>[];
+  private _fetch(
+    search_query: string,
+    searchType?: keyof SearchTypes,
+    requestedLang?: string
+  ): Promise<string>;
   private _getSearchData(webPage: string): Record<string, unknown>;
   private _parseData(data: Record<string, unknown>[]): Results;
 
-  public async search(query: string, options?: SearchOptions): Promise<Results>;
+  public search(query: string, options?: SearchOptions): Promise<Results>;
   public setLang(language?: string): void;
 }


### PR DESCRIPTION
I was getting some errors from the typing, so I fixed it.

```bash
node_modules/@yimura/scraper/index.d.ts:10:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

10 const Constants = {
   ~~~~~

node_modules/@yimura/scraper/index.d.ts:10:19 - error TS1254: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference.

10 const Constants = {
                     ~
11   SearchTypes,
   ~~~~~~~~~~~~~~
12   YoutubeURL: URL.prototype,
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
13 }
   ~

node_modules/@yimura/scraper/index.d.ts:11:3 - error TS2693: 'SearchTypes' only refers to a type, but is being used as a value here.

11   SearchTypes,
     ~~~~~~~~~~~

node_modules/@yimura/scraper/index.d.ts:92:10 - error TS1040: 'async' modifier cannot be used in an ambient context.

92   public async search(query: string, options?: SearchOptions): Promise<Results>;
            ~~~~~
```