### PR TITLE
fix(idToThumbnail): always use maxres

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -91,7 +91,7 @@ const getWatching = (vRender) => {
 }
 
 const idToThumbnail = function(id) {
-    return 'https://i.ytimg.com/vi/'+ id +'/hqdefault.jpg';
+    return 'https://i.ytimg.com/vi/'+ id +'/maxresdefault.jpg';
 }
 
 const parseDuration = (vRender) => {


### PR DESCRIPTION
Currently scrapper uses hqdefault for thumbnails which creates some bars.
Youtube provides the following resolutions:

`default`
`hqdefault`
`mqdefault`
`sddefault`
`maxresdefault`

It seems that only maxresdefault and mqdefault don't have them. A better solution would probably be to allow the function to take an extra parameter for the thumbnail quality.

fixes: https://github.com/Yimura/Scraper/issues/7