### PR TITLE
fix(util): parse duration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,8 @@ export interface ShareableGeneralData extends GeneralData {
 }
 
 export interface VideoPreview extends ShareableGeneralData {
-  duration: string;
+  duration: number;
+  duration_raw: string;
   views: number;
 }
 
@@ -37,7 +38,8 @@ export interface ChannelPreview {
 
 export interface Video extends ShareableGeneralData {
   description: string;
-  duration: string;
+  duration: number;
+  duration_raw: string;
   uploaded: string;
   views: number;
   channel: ChannelPreview;
@@ -45,6 +47,8 @@ export interface Video extends ShareableGeneralData {
 
 export interface Playlist extends GeneralData {
   preview: VideoPreview[];
+  duration: number;
+  duration_raw: string;
 }
 
 export interface Stream extends ShareableGeneralData {

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export interface ShareableGeneralData extends GeneralData {
 }
 
 export interface VideoPreview extends ShareableGeneralData {
-  duration: number;
+  duration: string;
   views: number;
 }
 
@@ -37,7 +37,7 @@ export interface ChannelPreview {
 
 export interface Video extends ShareableGeneralData {
   description: string;
-  duration: number;
+  duration: string;
   uploaded: string;
   views: number;
   channel: ChannelPreview;

--- a/src/Util.js
+++ b/src/Util.js
@@ -99,7 +99,7 @@ const parseDuration = (vRender) => {
     if (!vRender.lengthText) return 0;
 
     const nums = vRender.lengthText.simpleText.split(':');
-    let time = nums.split(':').reduce((a, t) => (60 * a) + +t) * 1e3;
+    let time = nums.reduce((a, t) => (60 * a) + +t) * 1e3;
 
     return time;
 }

--- a/src/Util.js
+++ b/src/Util.js
@@ -68,7 +68,7 @@ const getPlaylistThumbnail = (pRender) => {
 const getPlaylistVideoData = (renderer) => {
     return {
         duration: parseDuration(renderer),
-        duration_raw: renderer.lengthText ? renderer.lengthText.simpleText : '00:00:00'
+        duration_raw: renderer.lengthText ? renderer.lengthText.simpleText : '00:00:00',
         id: renderer.videoId,
         link: shareLink(renderer.videoId, false),
         thumbnail: idToThumbnail(renderer.videoId),
@@ -151,7 +151,7 @@ exports.getVideoData = (item) => {
     return assign({
         description: compress(vRender.descriptionSnippet),
         duration: parseDuration(vRender),
-        duration_raw: vRender.lengthText ? vRender.lengthText.simpleText : '00:00:00'
+        duration_raw: vRender.lengthText ? vRender.lengthText.simpleText : '00:00:00',
         uploaded: getUploadDate(vRender),
         views: getViews(vRender)
     }, getGeneralData(vRender));

--- a/src/Util.js
+++ b/src/Util.js
@@ -95,18 +95,8 @@ const idToThumbnail = function(id) {
 }
 
 const parseDuration = (vRender) => {
-    if (!vRender.lengthText) return 0;
-
-    const nums = vRender.lengthText.simpleText.split(':');
-    let sum = 0;
-    let multi = 1;
-
-    while (nums.length > 0) {
-        sum += multi * parseInt(nums.pop() || '-1', 10);
-        multi *= 60;
-    }
-
-    return sum;
+    if (!vRender.lengthText || !vRender.lengthText.simpleText) return '00:00:00';
+    return vRender.lengthText.simpleText
 }
 
 const shareLink = (id, short = true) => {

--- a/src/Util.js
+++ b/src/Util.js
@@ -68,6 +68,7 @@ const getPlaylistThumbnail = (pRender) => {
 const getPlaylistVideoData = (renderer) => {
     return {
         duration: parseDuration(renderer),
+        duration_raw: renderer.lengthText ? renderer.lengthText.simpleText : '00:00:00'
         id: renderer.videoId,
         link: shareLink(renderer.videoId, false),
         thumbnail: idToThumbnail(renderer.videoId),
@@ -95,8 +96,12 @@ const idToThumbnail = function(id) {
 }
 
 const parseDuration = (vRender) => {
-    if (!vRender.lengthText || !vRender.lengthText.simpleText) return '00:00:00';
-    return vRender.lengthText.simpleText
+    if (!vRender.lengthText) return 0;
+
+    const nums = vRender.lengthText.simpleText.split(':');
+    let time = nums.split(':').reduce((a, t) => (60 * a) + +t) * 1e3;
+
+    return time;
 }
 
 const shareLink = (id, short = true) => {
@@ -146,6 +151,7 @@ exports.getVideoData = (item) => {
     return assign({
         description: compress(vRender.descriptionSnippet),
         duration: parseDuration(vRender),
+        duration_raw: vRender.lengthText ? vRender.lengthText.simpleText : '00:00:00'
         uploaded: getUploadDate(vRender),
         views: getViews(vRender)
     }, getGeneralData(vRender));


### PR DESCRIPTION
There is no point in formatting the time of the videos like this, as it becomes useless.

For example, a video with a duration of `01:23:45` its time is converted to `12345`, that number is useless since it cannot be used to show how long the video is.